### PR TITLE
Admin oauth: Option to create admin user in case it does not exist

### DIFF
--- a/authlib/admin_oauth/views.py
+++ b/authlib/admin_oauth/views.py
@@ -86,7 +86,7 @@ def create_admin_user(request, email):
     user = None
     created = False
     if user_model.objects.filter(email=email).exists() == False:
-        user = user_model(email=email, is_active=True, is_staff=True)
+        user = user_model(email=email, is_active=True, is_staff=True, is_superuser=True)
         if getattr(user_model, 'USERNAME_FIELD', 'email') == 'username':
             user.username = email
         user.save()

--- a/authlib/admin_oauth/views.py
+++ b/authlib/admin_oauth/views.py
@@ -13,8 +13,11 @@ from django.utils.module_loading import import_string
 ADMIN_OAUTH_PATTERNS = settings.ADMIN_OAUTH_PATTERNS
 ADMIN_OAUTH_LOGIN_HINT = "admin-oauth-login-hint"
 ADMIN_OAUTH_CREATE_USER_IF_MISSING = getattr(settings, "ADMIN_OAUTH_CREATE_USER_IF_MISSING", False)
-ADMIN_OAUTH_CREATE_USER_CALLBACK = getattr(settings, "ADMIN_OAUTH_CREATE_USER_CALLBACK", None)
-
+ADMIN_OAUTH_CREATE_USER_CALLBACK = getattr(
+    settings,
+    "ADMIN_OAUTH_CREATE_USER_CALLBACK",
+    "authlib.admin_oauth.views.create_admin_user"
+)
 
 @never_cache
 @set_next_cookie
@@ -45,7 +48,7 @@ def admin_oauth(request):
                 if not user and ADMIN_OAUTH_CREATE_USER_IF_MISSING == True and ADMIN_OAUTH_CREATE_USER_CALLBACK is not None:
                     try:
                         create_user_method = import_string(ADMIN_OAUTH_CREATE_USER_CALLBACK)
-                        user, user_created = create_user_method(request, email)
+                        user, user_created = create_user_method(request, user_mail)
                     except ImportError as e:
                         messages.error(
                             request, _("Unable to import '%s' method") % ADMIN_OAUTH_CREATE_USER_CALLBACK
@@ -54,6 +57,10 @@ def admin_oauth(request):
                         messages.error(
                             request, _("Unable to create user with provided '%s' method") % ADMIN_OAUTH_CREATE_USER_CALLBACK
                         )
+                elif ADMIN_OAUTH_CREATE_USER_CALLBACK is None:
+                    messages.error(
+                        request, _("No user creation method provided")
+                    )
                 if user and user.is_staff:
                     if user_created == True:
                         user = auth.authenticate(email=user_mail)
@@ -72,3 +79,16 @@ def admin_oauth(request):
     response = redirect("admin:login")
     response.delete_cookie(ADMIN_OAUTH_LOGIN_HINT)
     return response
+
+def create_admin_user(request, email):
+    from django.contrib.auth import get_user_model
+    user_model = get_user_model()
+    user = None
+    created = False
+    if user_model.objects.filter(email=email).exists() == False:
+        user = user_model(email=email, is_active=True, is_staff=True)
+        if getattr(user_model, 'USERNAME_FIELD', 'email') == 'username':
+            user.username = email
+        user.save()
+        created = True
+    return user, created


### PR DESCRIPTION
Add the option to create an admin user in case if it doesn't exist, as long as the email domain matches the configured one. 

A new setting field (boolean) would be used for this: **ADMIN_OAUTH_CREATE_USER_IF_MISSING**.

This feature would be so usable in case you (or your development team/company) mantain several websites and want to grant admin access to everybody within that group without creating each user in each website.